### PR TITLE
Upgrade gocql

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,7 @@ module github.com/siteminder-au/terraform-provider-cassandra
 go 1.13
 
 require (
-	github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 // indirect
-	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
-	github.com/gocql/gocql v0.0.0-20181106112037-68ae1e384be4
+	github.com/gocql/gocql v0.0.0-20191106222750-ae2f7fc85f32
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.1.0
 	golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
-github.com/gocql/gocql v0.0.0-20181106112037-68ae1e384be4 h1:n5NlV76GU6337XT+jarynqONI5LlqaYkTPaFZ25og6g=
-github.com/gocql/gocql v0.0.0-20181106112037-68ae1e384be4/go.mod h1:4Fw1eo5iaEhDUs8XyuhSVCVy52Jq3L+/3GJgYkwc+/0=
+github.com/gocql/gocql v0.0.0-20191106222750-ae2f7fc85f32 h1:rCAnpA1hmiR2r7/fCAwj8Sr7fYrXW/1Ba5og11BcpRk=
+github.com/gocql/gocql v0.0.0-20191106222750-ae2f7fc85f32/go.mod h1:DL0ekTmBSTdlNF25Orwt/JMzqIq3EJ4MVa/J/uK64OY=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=


### PR DESCRIPTION
It seems like `instaclustr` have changed their auth provider, and the current version of `gocql` doesn't support it. This was resolved by https://github.com/gocql/gocql/pull/1321.

```

4 errors occurred:
--
  | * cassandra_keyspace.keyspace: 1 error occurred:
  | * cassandra_keyspace.keyspace: gocql: unable to create session: control: unable to connect to initial hosts: unexpected authenticator "com.ericsson.bss.cassandra.ecaudit.auth.AuditPasswordAuthenticator"
  |  
  |  
  | * cassandra_role.migration: 1 error occurred:
  | * cassandra_role.migration: gocql: unable to create session: control: unable to connect to initial hosts: unexpected authenticator "com.ericsson.bss.cassandra.ecaudit.auth.AuditPasswordAuthenticator"
  |  
  |  
  | * cassandra_role.readonly: 1 error occurred:
  | * cassandra_role.readonly: gocql: unable to create session: control: unable to connect to initial hosts: unexpected authenticator "com.ericsson.bss.cassandra.ecaudit.auth.AuditPasswordAuthenticator"
  |  
  |  
  | * cassandra_role.app: 1 error occurred:
  | * cassandra_role.app: gocql: unable to create session: control: unable to connect to initial hosts: unexpected authenticator "com.ericsson.bss.cassandra.ecaudit.auth.AuditPasswordAuthenticator"
  |  


```